### PR TITLE
Fix mobile layout for /bed planner on iPhone

### DIFF
--- a/src/components/grid/GridCell.module.css
+++ b/src/components/grid/GridCell.module.css
@@ -54,7 +54,7 @@
 }
 
 /* Icon fills most of the cell */
-.icon { width: 70px; height: 70px; object-fit: contain; }
+.icon { width: var(--cell-icon-size); height: var(--cell-icon-size); object-fit: contain; }
 
 /* Plants-per-square badge — top right corner */
 .countBadge {

--- a/src/components/layout/AppShell.module.css
+++ b/src/components/layout/AppShell.module.css
@@ -11,3 +11,7 @@
   margin: 0 auto;
   padding: var(--space-5) var(--space-4);
 }
+
+@media (max-width: 640px) {
+  .main { padding: var(--space-4) var(--space-3); }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,7 @@
 
   /* Grid */
   --cell-size:          88px;
+  --cell-icon-size:     70px;
   --grid-gap:           4px;
   --cell-radius:        4px;
 
@@ -119,6 +120,14 @@ body::after {
   z-index: 9999;
   opacity: 0.035;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* Mobile token overrides */
+@media (max-width: 640px) {
+  :root {
+    --cell-size:      64px;
+    --cell-icon-size: 48px;
+  }
 }
 
 /* Utility */

--- a/src/pages/BedPlannerPage.module.css
+++ b/src/pages/BedPlannerPage.module.css
@@ -63,7 +63,16 @@
 
 @media (max-width: 900px) {
   .layout { grid-template-columns: 1fr; }
-  .sidebar { position: static; max-height: none; }
+  .sidebar { position: static; max-height: none; max-width: none; min-width: 0; width: 100%; }
+}
+
+@media (max-width: 640px) {
+  .bedFrame {
+    border-width: 5px;
+    padding: 8px;
+  }
+  .pageHeader { gap: var(--space-3); }
+  .bedName { font-size: var(--font-size-xl); }
 }
 
 /* Grid area */


### PR DESCRIPTION
## Summary

- Reduce cell size to 64px and icon to 48px on screens ≤640px via CSS tokens
- Slim bed frame border (8→5px) and padding (12→8px) on mobile to reclaim space
- Sidebar stretches full width on mobile (removes max-width/min-width constraints)
- Tighten shell padding to 12px sides on mobile to maximise grid space

## Test plan

- [ ] Open `/bed` planner on iPhone (or devtools mobile viewport)
- [ ] Confirm a 4×4 bed fits without horizontal overflow
- [ ] Confirm sidebar fills full width below the grid
- [ ] Confirm desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)